### PR TITLE
Replace mylink with example

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -29,11 +29,11 @@
     <div id="footer">
       <p id="splash-text">Get started!</p>
       <img
-          src="splash-arrow.svg"
-          alt="Get started arrow"
-          id="splash-arrow"
-          draggable="false"
-        />
+        src="splash-arrow.svg"
+        alt="Get started arrow"
+        id="splash-arrow"
+        draggable="false"
+      />
       <button id="manage-btn" class="text-btn">Edit Links</button>
       <button id="done-btn" style="display: none">Done</button>
       <button id="add-link-btn" style="display: none">+ New Link</button>
@@ -51,7 +51,7 @@
             <input
               type="text"
               class="new-url"
-              placeholder="ex. https://www.mylink.com/"
+              placeholder="ex. https://www.example.com/"
             />
           </div>
         </div>


### PR DESCRIPTION
This change replaces the mylink domain with example.com.

Example.com is reserved for this purpose per https://en.wikipedia.org/wiki/Example.com, while mylink could be owned and used by someone.

Testing Instructions
---
1. Click "+ New Link"
2. See that the Link URL field contains "example.com"