### PR TITLE
Feature: Add new link button to main page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
         @copy="handleCopy"
         @edit="handleEdit"
         @reorder="handleReorder"
+        @add-link="handleAddLink"
       />
 
       <!-- Edit Mode / Empty State -->

--- a/src/components/LinksList.vue
+++ b/src/components/LinksList.vue
@@ -21,6 +21,9 @@
       <TextButton @click="handleEdit">
         {{ UI_TEXT.EDIT_LINKS_BUTTON }}
       </TextButton>
+      <PrimaryButton @click="handleAddLink">
+        {{ UI_TEXT.NEW_LINK_BUTTON }}
+      </PrimaryButton>
     </div>
   </div>
 </template>
@@ -29,6 +32,7 @@
 import { UI_TEXT } from '../constants'
 import type { Link } from '../types'
 import LinkItem from './LinkItem.vue'
+import PrimaryButton from './ui/PrimaryButton.vue'
 import TextButton from './ui/TextButton.vue'
 
 interface Props {
@@ -39,6 +43,7 @@ interface Emits {
   (e: 'copy', link: Link): void
   (e: 'edit'): void
   (e: 'reorder', newOrder: Link[]): void
+   (e: 'add-link'): void
 }
 
 defineProps<Props>()
@@ -50,5 +55,9 @@ function handleCopy(link: Link) {
 
 function handleEdit() {
   emit('edit')
+}
+
+function handleAddLink() {
+  emit('add-link')
 }
 </script>

--- a/src/components/LinksList.vue
+++ b/src/components/LinksList.vue
@@ -18,12 +18,12 @@
     <div
       class="flex-shrink-0 bg-[#e8e5e2] dark:bg-[#1e1e1e] backdrop-blur-[10px] p-3 flex justify-center items-center gap-3 min-h-7 dark:text-white"
     >
-      <TextButton @click="handleEdit">
-        {{ UI_TEXT.EDIT_LINKS_BUTTON }}
-      </TextButton>
       <PrimaryButton @click="handleAddLink">
         {{ UI_TEXT.NEW_LINK_BUTTON }}
       </PrimaryButton>
+      <TextButton @click="handleEdit">
+        {{ UI_TEXT.EDIT_LINKS_BUTTON }}
+      </TextButton>
     </div>
   </div>
 </template>
@@ -43,7 +43,7 @@ interface Emits {
   (e: 'copy', link: Link): void
   (e: 'edit'): void
   (e: 'reorder', newOrder: Link[]): void
-   (e: 'add-link'): void
+  (e: 'add-link'): void
 }
 
 defineProps<Props>()

--- a/vite.config.mjs.timestamp-1753555928624-06fe0c931f78f.mjs
+++ b/vite.config.mjs.timestamp-1753555928624-06fe0c931f78f.mjs
@@ -2,7 +2,6 @@
 import tailwindcss from "file:///Users/nate/Desktop/Dev/ditto-extension/node_modules/@tailwindcss/vite/dist/index.mjs";
 import vue from "file:///Users/nate/Desktop/Dev/ditto-extension/node_modules/@vitejs/plugin-vue/dist/index.mjs";
 import { defineConfig } from "file:///Users/nate/Desktop/Dev/ditto-extension/node_modules/vite/dist/node/index.js";
-
 // plugins/copyManifest.ts
 import * as fs from "fs";
 import * as path from "path";


### PR DESCRIPTION
Until https://github.com/tequirk/ditto-extension/issues/43 gets resolved, I think it would be nice to have the "New Link" button be present when you open the extension instead of having to click on "Edit Links" to add a new link. 

<img width="380" height="238" alt="image" src="https://github.com/user-attachments/assets/cf5a89c9-091b-4daa-9735-635403ea2b2b" />

